### PR TITLE
85 fixing header and footer design

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -19,6 +19,7 @@ button {
   align-items: center;
   margin-bottom: 2rem;
   max-width: 100%;
+  border-bottom: 0.125rem solid black;
 }
 
 .user-cart{
@@ -28,7 +29,7 @@ button {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 2rem;
+  margin-bottom: -0.5rem;
   max-width: 100%;
 }
 

--- a/client/src/Pages/Components/Footer.jsx
+++ b/client/src/Pages/Components/Footer.jsx
@@ -6,7 +6,7 @@ import LinkToServicesFooter from './Modules/LinkToServicesFooter';
 
 const Footer = () => {
   return (
-    <footer className="Footer">
+    <footer className="footer">
       <PageLogoLink />
       <SocialMediaLinks />
       <LinkToServicesFooter />

--- a/client/src/Pages/Components/Modules/Footer.css
+++ b/client/src/Pages/Components/Modules/Footer.css
@@ -1,49 +1,53 @@
-.Footer {
+.footer {
   background-color: white;
   width: 100%;
-  height: 25%;
+  height: 15%;
   box-sizing: border-box;
   margin-top: auto;
   bottom: 0%;
   position: absolute;
   padding-top: 1.5rem;
   border-top: 0.125rem solid black;
+  overflow-y: hidden;
 }
 
 
-.SocialMediaLogoContainer {
+.social-media-logo-container {
   display: flex;
   justify-content: left;
-  gap: 1em;
+  gap: 0.5em;
   width: fit-content;
   position: relative;
-  left: 5rem;
+  left: 5.25rem;
+  top: -1.5rem;
 }
 
 
-.SocialMedia-logo {
-  height: 2em;
+.social-media-logo {
+  height: 1.5em;
+
 }
 
-.pageLogoContainer {
+.page-logo-container {
   display: flex;
   justify-content: left;
   gap: 1em;
   width: fit-content;
   position: relative;
   left: 10vh;
+  top: -0.5rem;
 }
 
-.Page-Logo {
-  width:14rem;
+.page-logo {
+  width:10rem;
   padding-bottom: 1rem;
 }
 
-.Page-Logo:hover {
+.page-Logo:hover {
   cursor: pointer;
 }
 
-.LinksToServicesTextContainer {
+.links-to-services-text-container {
   display: flex;
   justify-content: flex-start; 
   align-items: flex-start; 
@@ -51,25 +55,25 @@
   padding-left: 50vh;
 }
 
-.LinksToServicesTextFooter1,
-.LinksToServicesTextFooter2,
-.LinksToServicesTextFooter3 {
+.links-to-services-text-footer1,
+.links-to-services-text-footer2,
+.links-to-services-text-footer3 {
   color: black;
   flex-direction: column;
   justify-content: flex-start;
   width: fit-content;
   position: relative;
-  margin-top: -10rem;
+  margin-top: -9.25rem;
   margin-left: 10vh; 
   margin-right: 10vh; 
   font-size:2vh;
 }
 
-.ContactUsTextLink,
-.CookiePolicyLink,
-.PersonalDataPolicyLink,
-.UpdateCookieSettingsLink,
-.LoginTUCLink {
+.contact-us-text-link,
+.cookie-policy-text-link,
+.personal-data-policy-text-link,
+.update-cookie-settings-text-link,
+.login-TUC-text-link {
   color: black;
   text-decoration: underline;
 }

--- a/client/src/Pages/Components/Modules/Footer.css
+++ b/client/src/Pages/Components/Modules/Footer.css
@@ -18,7 +18,7 @@
   gap: 0.5em;
   width: fit-content;
   position: relative;
-  left: 5.25rem;
+  left: 10vh;
   top: -1.5rem;
 }
 
@@ -66,7 +66,7 @@
   margin-top: -9.25rem;
   margin-left: 10vh; 
   margin-right: 10vh; 
-  font-size:2vh;
+  font-size: 1rem;
 }
 
 .contact-us-text-link,

--- a/client/src/Pages/Components/Modules/LinkToServicesFooter.jsx
+++ b/client/src/Pages/Components/Modules/LinkToServicesFooter.jsx
@@ -3,33 +3,31 @@ import { Link } from 'react-router-dom';
 
 const LinkToServicesFooter = () => {
     return (
-        <div className="LinksToServicesTextContainer">
-            <div className="LinksToServicesTextFooter1">
+        <div className="links-to-services-text-container">
+            <div className="links-to-services-text-footer1">
                 <p>We at CUT</p>
                 <p>Whistle blowing</p>
                 <p>Graphic manual</p>
-                <div className="LinkTextFooterContactUs">
-                    <Link to="/Contact">
-                        <div className="ContactUsTextLink">
-                            <p>Contact Us</p>
-                        </div>
-                    </Link>
-                </div>
+                <Link to="/Contact">
+                    <div className="contact-us-text-link">
+                        <p>Contact Us</p>
+                    </div>
+                </Link>
             </div>
-            <div className="LinksToServicesTextFooter2">
+            <div className="links-to-services-text-footer2">
                 <a href="https://www.tucsweden.se/cookiepolicy-tuc-yrkeshoskola/" target="_blank">
-                <div className="CookiePolicyLink"> <p>About the Website Cookie policy</p> </div>
+                    <div className="cookie-policy-text-link"> <p>About the Website Cookie policy</p> </div>
                 </a>
                 <a href="https://www.tucsweden.se/personuppgiftspolicy/" target="_blank">
-                <div className="PersonalDataPolicyLink"><p>Personal data policy</p> </div>
+                    <div className="personal-data-policy-text-link"><p>Personal data policy</p> </div>
                 </a>
                 <a href="https://www.tucsweden.se/uppdatera-dina-cookieinstillningar/" target="_blank">
-                <div className="UpdateCookieSettingsLink"> <p>View and update your cookie consent</p> </div>
+                    <div className="update-cookie-settings-text-link"> <p>View and update your cookie consent</p> </div>
                 </a>
             </div>
-            <div className="LinksToServicesTextFooter3">
+            <div className="links-to-services-text-footer3">
                 <a href="https://tucsweden.learnpoint.se/LoginForms/LoginForm.aspx?ReturnUrl=%2Fdefault.aspx" target="_blank">
-                <div className="LoginTUCLink"> <p>Log in to CUT</p> </div>
+                    <div className="login-TUC-text-link"> <p>Log in to CUT</p> </div>
                 </a>
             </div>
         </div>

--- a/client/src/Pages/Components/Modules/Logo.jsx
+++ b/client/src/Pages/Components/Modules/Logo.jsx
@@ -7,7 +7,7 @@ function Logo() {
   };
   return (
     <button onClick={handleclick}>
-      <img src={logo} alt="Home" width={250} data-testid="logo-image" />
+      <img src={logo} alt="Home" width={200} data-testid="logo-image" />
     </button>
   );
 }

--- a/client/src/Pages/Components/Modules/PageLogoLink.jsx
+++ b/client/src/Pages/Components/Modules/PageLogoLink.jsx
@@ -8,8 +8,8 @@ const PageLogoLink = () => {
   };
 
   return (
-    <div className="pageLogoContainer"> 
-      <img src={pageLogo} alt="Go to Home" onClick={handleClick} className="Page-Logo" />
+    <div className="page-logo-container"> 
+      <img src={pageLogo} alt="Go to Home" onClick={handleClick} className="page-logo" />
     </div>
   );
 };

--- a/client/src/Pages/Components/Modules/SocialMediaLinks.jsx
+++ b/client/src/Pages/Components/Modules/SocialMediaLinks.jsx
@@ -8,21 +8,21 @@ import facebookLogo from './Images/facebook-logo.png';
 
 const SocialMediaLinks = () => {
   return (
-    <div className = "SocialMediaLogoContainer">
+    <div className = "social-media-logo-container">
       <a href="https://www.tiktok.com/discover/tuc-h%C3%B6gskola-j%C3%B6nk%C3%B6ping" target="_blank">
-        <img src={tiktokLogo} alt="Tiktok" className="SocialMedia-logo" />
+        <img src={tiktokLogo} alt="Tiktok" className="social-media-logo" />
       </a>
       <a href="https://www.youtube.com/user/TUCtelevision" target="_blank">
-        <img src={youtubeLogo} alt="Youtube" className="SocialMedia-logo" />
+        <img src={youtubeLogo} alt="Youtube" className="social-media-logo" />
       </a>
       <a href="https://www.linkedin.com/company/tuc-sweden-ab/?originalSubdomain=se" target="_blank">
-        <img src={linkedinLogo} alt="linkedin" className="SocialMedia-logo" />
+        <img src={linkedinLogo} alt="linkedin" className="social-media-logo" />
       </a>
       <a href="https://www.instagram.com/tucyrkeshogskola/" target="_blank">
-        <img src={instagramLogo} alt="Instagram" className="SocialMedia-logo" />
+        <img src={instagramLogo} alt="Instagram" className="social-media-logo" />
       </a>
       <a href="https://www.facebook.com/tucsweden/?locale2=en_GB&_rdr" target="_blank">
-        <img src={facebookLogo} alt="Facebook" className="SocialMedia-logo" />
+        <img src={facebookLogo} alt="Facebook" className="social-media-logo" />
       </a>
     </div>
   );

--- a/client/src/Pages/Tests/LogoTest.test.jsx
+++ b/client/src/Pages/Tests/LogoTest.test.jsx
@@ -19,7 +19,7 @@ vi.mock("../Componets/Modules/Logo", () => ({
         <img
           src="/public/logo.png"
           alt="logo"
-          width={250}
+          width={200}
           data-testid="logo-image"
         />
       </button>
@@ -41,6 +41,6 @@ describe("Logo Component", () => {
 
     expect(image).toHaveAttribute("src", "/public/logo.png");
     expect(image).toHaveAttribute("alt", "Home");
-    expect(image).toHaveAttribute("width", "250");
+    expect(image).toHaveAttribute("width", "200");
   });
 });


### PR DESCRIPTION
fixed the css names for the footer components and in the Footer.css file to match the css naming convention in App.css.

I also edited the css so that the footer took up a smaller amount of space and the parts in it scaled as  the other things on the page when you zoom in and out on the page.

I also edited the header so that it took up less space aswell, then i added css to add a line underneath it to seperate the header from the main page content more clearly.

I also edited the css so that the items in the header and footer fit inside the new size set for it

Finally i edited the code which sets the size of the Logo.jsx img from 250 in width to 200 and changed the test to match this so it no longer tested if it was 250 in width but instead 200

